### PR TITLE
Naprawa linku discord

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -53,7 +53,7 @@ Poniżej znajdziesz wszytko, co jest Ci potrzebne do rozpoczęcia przygody z ser
 Jeśli powyższe materiały nie okazały się wystarczająco pomocne, zawsze możesz poszukać pomocy w tych dwóch miejscach:
 
 - [**Grupa na Facebooku**](https://www.facebook.com/groups/mikrusy)
-- [**Serwer na Discord**](https://discord.gg/hfcqjgkppq)
+- [**Serwer na Discord**](https://discord.gg/hFcqJGkppq)
 
 Potrzebujesz więcej wiedzy? 👇 
 


### PR DESCRIPTION
Zaktualizowano link do discorda, który był nieaktywny na link z głównej strony mikr.us